### PR TITLE
V1.1 Release Candidate

### DIFF
--- a/rajhin.sh
+++ b/rajhin.sh
@@ -4,13 +4,49 @@
 #    ______      ____    ____        ____   ____            ____           ____  ____  
 #  >   /  /___/ /___    /___/ /   / /___/  /___/  / / \  / / __    /    / /___/ /___/ <
 # >   /  /   / /___    /     /___/ /   \  /   \  / /   \/ /___/   /__  / /   / /   \ <
-d1=$(tr -dc 'A-F0-9' < /dev/urandom | head -c2)
-d2=$(tr -dc 'A-F0-9' < /dev/urandom | head -c2)
-d3=$(tr -dc 'A-F0-9' < /dev/urandom | head -c2)
-interfaces=($(basename -a /sys/class/net/* | grep -v lo))
+
+sudo echo "Executing Rajhin"
+
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+function RandHex(){
+	OneByte=$(tr -dc 'A-F0-9' < /dev/random | head -c2)
+	echo "$OneByte"
+}
+
+# Add list of vendors
+declare -a OUIarray=(00:50:E4 00:56:CD 10:A5:1D 00:e0:4c)
+OUI=$(shuf -n1 -e "${OUIarray[@]}")
+
+# Cryptographically secure, because you know it.
+SecretKey=$(uuidgen | sed "s/-//g; s/..../:&/g; s/^://")
+
+# Enforce RFC 4941 (AKA "Privacy Extensions") 
+# This decouples the last three fields of the IPv6 StateLess Address Auto-Config (SLAAC) from the EUI-48 on default net adapters. 
+sysctl -w net.ipv6.conf.default.use_tempaddr=2
+
+
+# Enable RFC 7217 (AKA "Semantically Opaque Interface Identifiers")
+# This makes the IPv6 SLAAC from an opaque hash.
+# This address is still "static" per network.
+# Yes, it changes every time you run the script.
+
+sysctl -w net.ipv6.conf.default.stable_secret="$SecretKey"
+
+interfaces=($(find /sys/class/net/* | grep -v "lo" | cut -d'/' -f5))
 for i in "${interfaces[@]}"
 do
-	ifconfig "$i" down
-	ifconfig "$i" hw ether 00:e0:4c:"$d1":"$d2":"$d3"
-	ifconfig "$i" up
+	# of the interface is up
+	AdapterStatus=$(cat /sys/class/net/"$i"/operstate)
+	if [[ $AdapterStatus == "up" ]]; then
+		ifconfig "$i" down
+		ifconfig "$i" hw ether "$OUI":"$(RandHex)":"$(RandHex)":"$(RandHex)"
+		ifconfig "$i" up
+		echo New EUI-48 for "$i" = "$OUI":"$(RandHex)":"$(RandHex)":"$(RandHex)"
+	fi
 done
+

--- a/rajhin.sh
+++ b/rajhin.sh
@@ -29,12 +29,10 @@ SecretKey=$(uuidgen | sed "s/-//g; s/..../:&/g; s/^://")
 # This decouples the last three fields of the IPv6 StateLess Address Auto-Config (SLAAC) from the EUI-48 on default net adapters. 
 sysctl -w net.ipv6.conf.default.use_tempaddr=2
 
-
 # Enable RFC 7217 (AKA "Semantically Opaque Interface Identifiers")
 # This makes the IPv6 SLAAC from an opaque hash.
 # This address is still "static" per network.
 # Yes, it changes every time you run the script.
-
 sysctl -w net.ipv6.conf.default.stable_secret="$SecretKey"
 
 interfaces=($(find /sys/class/net/* | grep -v "lo" | cut -d'/' -f5))
@@ -49,4 +47,3 @@ do
 		echo New EUI-48 for "$i" = "$OUI":"$(RandHex)":"$(RandHex)":"$(RandHex)"
 	fi
 done
-

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 
 ![GitHub issues](https://img.shields.io/github/issues/Operational-Sciences-Group/rajhin?logo=Github&style=plastic)
 ![GitHub top language](https://img.shields.io/github/languages/top/Operational-Sciences-Group/rajhin?logo=Bash&style=plastic)
-![Version](https://img.shields.io/badge/Version-1.0-sucess?style=plastic)
+![Version](https://img.shields.io/badge/Version-1.1-sucess?style=plastic)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/Operational-Sciences-Group/rajhin?style=plastic)
 
 ## Table of contents

--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,11 @@
 
 ## About
 
-Rajhin is a bash script for automatically spoofing the MAC address of all external ethernet interfaces on linux systems.  
+Rajhin is a bash script for automatically spoofing the EUI-48 address of all external ethernet interfaces on linux systems. Additionally, it enables [RFC 4941](https://datatracker.ietf.org/doc/html/rfc4941) and [RFC 7217](https://datatracker.ietf.org/doc/html/rfc7217) features within the linux kernel.
 The intended use case to configure the rajhin script to execute at system startup, however the script can be executed manually via typical script execution methods when physical address reset is desired.
 Rajhin will detect all active interfaces (eth0, wlan0, wlan1, etc.) and filter out the loopback address (lo) for spoofing.
-Spoofing is comprised of randomizing the three hexadecimal octets that comprise the NIC specific address, and appending them to the OUI address for Realtek ethernet drivers.
-The idea is that a recognizable though vague OUI used in a wide range of devices provides a less suspicious address than a purely random one.
+Spoofing is comprised of randomizing the three hexadecimal octets that comprise the NIC specific address, and appending them to the OUI address for common vendors.
+The idea is that a recognizable though vague OUI (Organizationally Unique Identifier) used in a wide range of devices provides a less suspicious address than a purely random one.
 
 ## Installation / Usage
 


### PR DESCRIPTION
Added:
- Privilege check before execution
- Several OUIs
- Now enables RFC 4941 (IPv6 Privacy extensions). The SLAAC Ipv6 address is
  not longer derived from the EUI-48. Uses temporary, pseudo-random Ipv6
  addresses in the absence of a DHCP server.
- Now enables RFC 7217. SLAAC IPv6 addresses configured using this method are
   stable within each subnet, but the corresponding Interface Identifier
   changes when the host moves from one network to another.

Improved:

- No longer assigns the same EUI-48 to multiple interfaces
- No longer turns on network adapters that were off when the script was run.
- Removed dependency on "basename", even though it is a GNU coreutil.
- Removed repetitive variables.
- Changed "dev/urandom" to "/dev/random" for older distro security.

